### PR TITLE
Gestion du Warning message dans Guyafor2df

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ src/*.so
 src/*.dll
 # pkgdown by GH Actions
 docs/
+.DS_Store

--- a/R/Guyafor.R
+++ b/R/Guyafor.R
@@ -87,10 +87,10 @@ QueryGuyafor <- function (WHERE, UID, PWD, Driver, codeWHERE = NULL) {
     connection_string <- paste(connection_string, "UID={", UID, "};PWD={", PWD, "};", sep="")
   }
   # Tentative de connexion
-  con <- NA
+  con <- NULL
   tryCatch(con <- odbc::dbConnect(odbc::odbc(), .connection_string=connection_string),
            error = function(e) e)
-  if (is.na(con)) {
+  if (is.null(con)) {
     warning(paste("La connexion à la base Guyafor a échoué.\n
     Vérifiez que le pilote ODBC",
     Driver,


### PR DESCRIPTION
Gestion du Warning message: 
    In is.na(con) :     is.na() appliqué à un objet de type 'S4' qui n'est ni une liste, ni un vecteur 
(apparaissant uniquement lorsque la connection est établie au serveur sql)